### PR TITLE
Fixed typo

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ output();
 
 // Check for executables
 let found = false;
-for(let exe in executables) {
+for(let exe of executables) {
     if(fs.existsSync(path.resolve(Game.getPath(), exe))) {
         found = true;
     }


### PR DESCRIPTION
Looping through the preset executables (gta-sa.exe/gta_sa.exe) with `in` was returning the indexes of the array and not the names.